### PR TITLE
Feat/other demos

### DIFF
--- a/src/lib/form/client-form-handler.svelte.ts
+++ b/src/lib/form/client-form-handler.svelte.ts
@@ -68,6 +68,8 @@ export class ClientFormHandler<
   #fields: SvelteMap<FormName<T>, Field<T>>;
   #enhanceAttachmentKey: symbol;
   #enhanceAttachment: Attachment<HTMLFormElement>;
+  #novalidateKey: symbol;
+  #novalidateAttachment: Attachment<HTMLFormElement>;
 
   constructor(
     schema: FormSchema<T>,
@@ -127,6 +129,12 @@ export class ClientFormHandler<
     this.#valid = $derived(Object.keys(this.#errors).length === 0);
     this.#submitting = $state(false);
     this.#success = $state(initialState?.success ?? undefined);
+
+    this.#novalidateKey = createAttachmentKey();
+    this.#novalidateAttachment = fromAction((node: HTMLFormElement) => {
+      node.setAttribute('novalidate', '');
+      return { destroy() { node.removeAttribute('novalidate'); } };
+    });
 
     this.#enhanceAttachmentKey = createAttachmentKey();
     this.#enhanceAttachment = fromAction(
@@ -307,6 +315,7 @@ export class ClientFormHandler<
       id: this.#formId,
       method: 'post',
       ...(hasFileField ? { enctype: 'multipart/form-data' } : {}),
+      [this.#novalidateKey]: this.#novalidateAttachment,
       [this.#enhanceAttachmentKey]: this.#enhanceAttachment,
       onfocusout: (event) => {
         const target = event.target as HTMLInputElement;

--- a/src/lib/form/client-form-handler.svelte.ts
+++ b/src/lib/form/client-form-handler.svelte.ts
@@ -300,12 +300,18 @@ export class ClientFormHandler<
   }
 
   attributes(): HTMLFormAttributes {
+    const hasFileField = this.#fieldDefinitions
+      .values()
+      .some((def) => def.castType === 'file');
     return {
       id: this.#formId,
       method: 'post',
+      ...(hasFileField ? { enctype: 'multipart/form-data' } : {}),
       [this.#enhanceAttachmentKey]: this.#enhanceAttachment,
       onfocusout: (event) => {
-        const name = (event.target as HTMLInputElement).name as FormName<T>;
+        const target = event.target as HTMLInputElement;
+        if (target.type === 'file') return;
+        const name = target.name as FormName<T>;
         if (name) {
           this.touch(name);
         }
@@ -369,7 +375,10 @@ class FileField<T extends FormShape, IsArray extends boolean> extends Field<
       name: this.name,
       id: this.id,
       type: 'file',
-      multiple: this.definition.isArray
+      multiple: this.definition.isArray,
+      onchange: () => {
+        this.handler.touch(this.name as FormName<T>);
+      }
     };
   }
 }

--- a/src/lib/form/utils.ts
+++ b/src/lib/form/utils.ts
@@ -187,7 +187,13 @@ export const formDataToPojo = <T extends FormShape>(
 
   const pojo: Record<string, unknown> = {};
   for (const def of defs) {
-    const values = formData.getAll(def.name);
+    // Browsers submit a single empty File placeholder when no file is selected.
+    // Filter those out so the logic below sees an empty list correctly.
+    const rawValues = formData.getAll(def.name);
+    const values =
+      def.castType === 'file'
+        ? rawValues.filter((v) => v instanceof File && v.name !== '')
+        : rawValues;
     if (values.length === 0) {
       if (def.castType === 'boolean') {
         setAtPath(pojo, def.name, false);

--- a/src/routes/form/demos/+page.svelte
+++ b/src/routes/form/demos/+page.svelte
@@ -21,26 +21,25 @@
   ]}
 >
   <ul>
-    <li>
-      <a href={resolve('/form/demos/boolean')}>Boolean</a>
-    </li>
-    <li>
-      <a href={resolve('/form/demos/select')}>Select</a>
-    </li>
-    <li>
-      <a href={resolve('/form/demos/radios')}>Radios</a>
-    </li>
-    <li>
-      <a href={resolve('/form/demos/select-multiple')}>Select (multiple)</a>
-    </li>
-     <li>
-      <a href={resolve('/form/demos/checkboxes')}>Checkboxes</a>
-    </li>
-    <li>
-      <a href={resolve('/form/demos/file')}>File (single)</a>
-    </li>
-    <li>
-      <a href={resolve('/form/demos/file-multiple')}>File (multiple)</a>
-    </li>
+    <li><a href={resolve('/form/demos/text')}>Text</a></li>
+    <li><a href={resolve('/form/demos/email')}>Email</a></li>
+    <li><a href={resolve('/form/demos/password')}>Password</a></li>
+    <li><a href={resolve('/form/demos/search')}>Search</a></li>
+    <li><a href={resolve('/form/demos/tel')}>Tel</a></li>
+    <li><a href={resolve('/form/demos/url')}>URL</a></li>
+    <li><a href={resolve('/form/demos/date')}>Date</a></li>
+    <li><a href={resolve('/form/demos/time')}>Time</a></li>
+    <li><a href={resolve('/form/demos/datetime-local')}>Datetime-Local</a></li>
+    <li><a href={resolve('/form/demos/month')}>Month</a></li>
+    <li><a href={resolve('/form/demos/week')}>Week</a></li>
+    <li><a href={resolve('/form/demos/color')}>Color</a></li>
+    <li><a href={resolve('/form/demos/textarea')}>Textarea</a></li>
+    <li><a href={resolve('/form/demos/boolean')}>Boolean</a></li>
+    <li><a href={resolve('/form/demos/select')}>Select</a></li>
+    <li><a href={resolve('/form/demos/radios')}>Radios</a></li>
+    <li><a href={resolve('/form/demos/select-multiple')}>Select (multiple)</a></li>
+    <li><a href={resolve('/form/demos/checkboxes')}>Checkboxes</a></li>
+    <li><a href={resolve('/form/demos/file')}>File (single)</a></li>
+    <li><a href={resolve('/form/demos/file-multiple')}>File (multiple)</a></li>
   </ul>
 </Route>

--- a/src/routes/form/demos/+page.svelte
+++ b/src/routes/form/demos/+page.svelte
@@ -34,6 +34,8 @@
     <li><a href={resolve('/form/demos/week')}>Week</a></li>
     <li><a href={resolve('/form/demos/color')}>Color</a></li>
     <li><a href={resolve('/form/demos/textarea')}>Textarea</a></li>
+    <li><a href={resolve('/form/demos/number')}>Number</a></li>
+    <li><a href={resolve('/form/demos/range')}>Range</a></li>
     <li><a href={resolve('/form/demos/boolean')}>Boolean</a></li>
     <li><a href={resolve('/form/demos/select')}>Select</a></li>
     <li><a href={resolve('/form/demos/radios')}>Radios</a></li>

--- a/src/routes/form/demos/+page.svelte
+++ b/src/routes/form/demos/+page.svelte
@@ -36,6 +36,11 @@
      <li>
       <a href={resolve('/form/demos/checkboxes')}>Checkboxes</a>
     </li>
-    
+    <li>
+      <a href={resolve('/form/demos/file')}>File (single)</a>
+    </li>
+    <li>
+      <a href={resolve('/form/demos/file-multiple')}>File (multiple)</a>
+    </li>
   </ul>
 </Route>

--- a/src/routes/form/demos/color/+page.server.ts
+++ b/src/routes/form/demos/color/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { colorFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './ColorForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, colorFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'ColorForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(colorFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, colorFormSchema, handler.data);
+    return handler.succeed({ message: `You picked "${handler.data.color}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/color/+page.svelte
+++ b/src/routes/form/demos/color/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import ColorForm from './ColorForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Color Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/color'), label: 'Color' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><ColorForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/color/ColorForm.svelte
+++ b/src/routes/form/demos/color/ColorForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { colorFormSchema, type ColorFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: ColorFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    colorFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('color').id}>Color</label>
+        <input
+          {...form.field('color').attributes({ as: 'color' })}
+          class="control"
+          class:invalid={form.shownErrors['color']}
+          aria-describedby={form.field('color').id + 'desc'}
+        />
+        <div id={form.field('color').id + 'desc'}>
+          {#if form.shownErrors['color']}
+            <div class="text-red-600">{form.shownErrors['color']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/color/schema.ts
+++ b/src/routes/form/demos/color/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const colorFormSchema = z.object({
+  color: z.string().min(1, 'Required.')
+});
+export type ColorFormData = z.infer<typeof colorFormSchema>;

--- a/src/routes/form/demos/date/+page.server.ts
+++ b/src/routes/form/demos/date/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { dateFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './DateForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, dateFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'DateForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(dateFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, dateFormSchema, handler.data);
+    return handler.succeed({ message: `You selected "${handler.data.date}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/date/+page.svelte
+++ b/src/routes/form/demos/date/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import DateForm from './DateForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Date Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/date'), label: 'Date' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><DateForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/date/DateForm.svelte
+++ b/src/routes/form/demos/date/DateForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { dateFormSchema, type DateFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: DateFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    dateFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('date').id}>Date</label>
+        <input
+          {...form.field('date').attributes({ as: 'date' })}
+          class="control"
+          class:invalid={form.shownErrors['date']}
+          aria-describedby={form.field('date').id + 'desc'}
+        />
+        <div id={form.field('date').id + 'desc'}>
+          {#if form.shownErrors['date']}
+            <div class="text-red-600">{form.shownErrors['date']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/date/schema.ts
+++ b/src/routes/form/demos/date/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const dateFormSchema = z.object({
+  date: z.string().min(1, 'Required.')
+});
+export type DateFormData = z.infer<typeof dateFormSchema>;

--- a/src/routes/form/demos/datetime-local/+page.server.ts
+++ b/src/routes/form/demos/datetime-local/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { datetimeLocalFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './DatetimeLocalForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, datetimeLocalFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'DatetimeLocalForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(datetimeLocalFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, datetimeLocalFormSchema, handler.data);
+    return handler.succeed({ message: `You selected "${handler.data.datetime}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/datetime-local/+page.svelte
+++ b/src/routes/form/demos/datetime-local/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import DatetimeLocalForm from './DatetimeLocalForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Datetime-Local Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/datetime-local'), label: 'Datetime-Local' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><DatetimeLocalForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/datetime-local/DatetimeLocalForm.svelte
+++ b/src/routes/form/demos/datetime-local/DatetimeLocalForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { datetimeLocalFormSchema, type DatetimeLocalFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: DatetimeLocalFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    datetimeLocalFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('datetime').id}>Date &amp; Time</label>
+        <input
+          {...form.field('datetime').attributes({ as: 'datetime-local' })}
+          class="control"
+          class:invalid={form.shownErrors['datetime']}
+          aria-describedby={form.field('datetime').id + 'desc'}
+        />
+        <div id={form.field('datetime').id + 'desc'}>
+          {#if form.shownErrors['datetime']}
+            <div class="text-red-600">{form.shownErrors['datetime']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/datetime-local/schema.ts
+++ b/src/routes/form/demos/datetime-local/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const datetimeLocalFormSchema = z.object({
+  datetime: z.string().min(1, 'Required.')
+});
+export type DatetimeLocalFormData = z.infer<typeof datetimeLocalFormSchema>;

--- a/src/routes/form/demos/email/+page.server.ts
+++ b/src/routes/form/demos/email/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { emailFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './EmailForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, emailFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'EmailForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(emailFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, emailFormSchema, handler.data);
+    return handler.succeed({ message: `You entered "${handler.data.email}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/email/+page.svelte
+++ b/src/routes/form/demos/email/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import EmailForm from './EmailForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Email Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/email'), label: 'Email' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><EmailForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/email/EmailForm.svelte
+++ b/src/routes/form/demos/email/EmailForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { emailFormSchema, type EmailFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: EmailFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    emailFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('email').id}>Email</label>
+        <input
+          {...form.field('email').attributes({ as: 'email' })}
+          class="control"
+          class:invalid={form.shownErrors['email']}
+          aria-describedby={form.field('email').id + 'desc'}
+        />
+        <div id={form.field('email').id + 'desc'}>
+          {#if form.shownErrors['email']}
+            <div class="text-red-600">{form.shownErrors['email']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/email/schema.ts
+++ b/src/routes/form/demos/email/schema.ts
@@ -1,0 +1,11 @@
+import z from 'zod';
+
+export const emailFormSchema = z.object({
+  email: z
+    .string({ error: 'Required.' })
+    .trim()
+    .toLowerCase()
+    .min(1, { error: 'Required.' })
+    .pipe(z.email({ error: 'Invalid email.' }))
+});
+export type EmailFormData = z.infer<typeof emailFormSchema>;

--- a/src/routes/form/demos/file-multiple/+page.server.ts
+++ b/src/routes/form/demos/file-multiple/+page.server.ts
@@ -1,0 +1,66 @@
+import {
+  deleteDemoCookie,
+  getDemoCookie,
+  setDemoCookie
+} from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { fileMultipleFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './FileMultipleForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, fileMultipleFormSchema),
+    code: [
+      {
+        label: 'schema.ts',
+        language: 'typescript',
+        code: schemaTs
+      },
+      {
+        label: 'FileMultipleForm.svelte',
+        language: 'html',
+        code: formSvelte
+      },
+      {
+        label: '+page.svelte',
+        language: 'html',
+        code: pageSvelte
+      },
+      {
+        label: '+page.server.ts',
+        language: 'typescript',
+        code: pageServerTs
+      }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(
+      fileMultipleFormSchema,
+      await event.request.formData(),
+      event
+    );
+    if (!handler.valid) {
+      return handler.fail();
+    }
+    setDemoCookie(event, fileMultipleFormSchema, handler.data);
+    const names = handler.data.files.map((f) => f.name).join(', ');
+    return handler.succeed({
+      message: `You uploaded ${handler.data.files.length} file(s): ${names}.`,
+      randomNum: Math.random()
+    });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/file-multiple/+page.svelte
+++ b/src/routes/form/demos/file-multiple/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Route from '$demo/components/Route.svelte';
   import { resolve } from '$app/paths';
-  import BooleanForm from './BooleanForm.svelte';
+  import FileMultipleForm from './FileMultipleForm.svelte';
   import CodeTabs from '$demo/components/CodeTabs.svelte';
 
   let { data, form } = $props();
@@ -9,7 +9,7 @@
 
 <Route
   fullWidth
-  pageTitle="Boolean Checkbox"
+  pageTitle="Multiple Files"
   breadcrumbs={[
     {
       href: resolve('/'),
@@ -24,14 +24,14 @@
       label: 'Demos'
     },
     {
-      href: resolve('/form/demos/boolean'),
-      label: 'Boolean'
+      href: resolve('/form/demos/file-multiple'),
+      label: 'File (multiple)'
     }
   ]}
 >
   <div class="grid items-start lg:grid-cols-2 gap-16">
     <div>
-      <BooleanForm actionData={form} savedData={data.saved} />
+      <FileMultipleForm actionData={form} savedData={data.saved} />
     </div>
     <div>
       <CodeTabs tabs={data.code} />

--- a/src/routes/form/demos/file-multiple/FileMultipleForm.svelte
+++ b/src/routes/form/demos/file-multiple/FileMultipleForm.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { fileMultipleFormSchema, type FileMultipleFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = {
+    actionData: ActionData;
+    savedData?: FileMultipleFormData;
+  };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    fileMultipleFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('files').id}>Files</label>
+        <input
+          {...form.field('files').attributes()}
+          class="control"
+          class:invalid={form.shownErrors['files']}
+        />
+
+        <div id={form.field('files').id + 'desc'}>
+          {#if form.shownErrors['files']}
+            <div class="text-red-600">
+              {form.shownErrors['files']}
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/file-multiple/schema.ts
+++ b/src/routes/form/demos/file-multiple/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const fileMultipleFormSchema = z.object({
+  files: z.array(z.file())
+});
+export type FileMultipleFormData = z.infer<typeof fileMultipleFormSchema>;

--- a/src/routes/form/demos/file/+page.server.ts
+++ b/src/routes/form/demos/file/+page.server.ts
@@ -1,0 +1,70 @@
+import {
+  deleteDemoCookie,
+  getDemoCookie,
+  setDemoCookie
+} from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { fileFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './FileForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, fileFormSchema),
+    code: [
+      {
+        label: 'schema.ts',
+        language: 'typescript',
+        code: schemaTs
+      },
+      {
+        label: 'FileForm.svelte',
+        language: 'html',
+        code: formSvelte
+      },
+      {
+        label: '+page.svelte',
+        language: 'html',
+        code:  pageSvelte
+      },
+      {
+        label: '+page.server.ts',
+        language: 'typescript',
+        code: pageServerTs
+      }
+    ]
+  };
+};
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(
+      fileFormSchema,
+      await event.request.formData(),
+      event
+    );
+    if (!handler.valid) {
+      return handler.fail();
+    }
+    // arbitrary server error...
+    // if (handler.data.planetsVisited.includes('Pluto') ) {
+    //   return handler.fail({
+    //     planetsVisited: 'Sorry. Pluto has been recently discontinued as a planet.'
+    //   });
+    // }
+    setDemoCookie(event, fileFormSchema, handler.data);
+    return handler.succeed({
+      message: `You uploaded ${handler.data.file.name}.`,
+      randomNum: Math.random()
+    });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/file/+page.svelte
+++ b/src/routes/form/demos/file/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Route from '$demo/components/Route.svelte';
   import { resolve } from '$app/paths';
-  import BooleanForm from './BooleanForm.svelte';
+  import FileForm from './FileForm.svelte';
   import CodeTabs from '$demo/components/CodeTabs.svelte';
 
   let { data, form } = $props();
@@ -9,7 +9,7 @@
 
 <Route
   fullWidth
-  pageTitle="Boolean Checkbox"
+  pageTitle="Single File"
   breadcrumbs={[
     {
       href: resolve('/'),
@@ -24,14 +24,14 @@
       label: 'Demos'
     },
     {
-      href: resolve('/form/demos/boolean'),
-      label: 'Boolean'
+      href: resolve('/form/demos/file'),
+      label: 'File'
     }
   ]}
 >
   <div class="grid items-start lg:grid-cols-2 gap-16">
     <div>
-      <BooleanForm actionData={form} savedData={data.saved} />
+      <FileForm actionData={form} savedData={data.saved} />
     </div>
     <div>
       <CodeTabs tabs={data.code} />

--- a/src/routes/form/demos/file/FileForm.svelte
+++ b/src/routes/form/demos/file/FileForm.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { fileFormSchema, type FileFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = {
+    actionData: ActionData;
+    savedData?: FileFormData;
+  };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    fileFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('file').id}>File</label>
+        <input
+          {...form.field('file').attributes()}
+          class="control"
+          class:invalid={form.shownErrors['file']}
+        />
+
+        <div id={form.field('file').id + 'desc'}>
+          {#if form.shownErrors['file']}
+            <div class="text-red-600">
+              {form.shownErrors['file']}
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/file/FileForm.svelte
+++ b/src/routes/form/demos/file/FileForm.svelte
@@ -19,7 +19,7 @@
 <div class="space-y-8">
   <div class="border border-gray-200">
     <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
-    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+    <form {...form.attributes()}  action="?/selectDemo" class="space-y-4 p-4">
       <div class="space-y-1">
         <label for={form.field('file').id}>File</label>
         <input

--- a/src/routes/form/demos/file/schema.ts
+++ b/src/routes/form/demos/file/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const fileFormSchema = z.object({
+  file: z.file()
+});
+export type FileFormData = z.infer<typeof fileFormSchema>;

--- a/src/routes/form/demos/month/+page.server.ts
+++ b/src/routes/form/demos/month/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { monthFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './MonthForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, monthFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'MonthForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(monthFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, monthFormSchema, handler.data);
+    return handler.succeed({ message: `You selected "${handler.data.month}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/month/+page.svelte
+++ b/src/routes/form/demos/month/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import MonthForm from './MonthForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Month Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/month'), label: 'Month' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><MonthForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/month/MonthForm.svelte
+++ b/src/routes/form/demos/month/MonthForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { monthFormSchema, type MonthFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: MonthFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    monthFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('month').id}>Month</label>
+        <input
+          {...form.field('month').attributes({ as: 'month' })}
+          class="control"
+          class:invalid={form.shownErrors['month']}
+          aria-describedby={form.field('month').id + 'desc'}
+        />
+        <div id={form.field('month').id + 'desc'}>
+          {#if form.shownErrors['month']}
+            <div class="text-red-600">{form.shownErrors['month']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/month/schema.ts
+++ b/src/routes/form/demos/month/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const monthFormSchema = z.object({
+  month: z.string().min(1, 'Required.')
+});
+export type MonthFormData = z.infer<typeof monthFormSchema>;

--- a/src/routes/form/demos/number/+page.server.ts
+++ b/src/routes/form/demos/number/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { numberFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './NumberForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, numberFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'NumberForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(numberFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, numberFormSchema, handler.data);
+    return handler.succeed({ message: `You entered ${handler.data.count}.`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/number/+page.svelte
+++ b/src/routes/form/demos/number/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import NumberForm from './NumberForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Number Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/number'), label: 'Number' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><NumberForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/number/NumberForm.svelte
+++ b/src/routes/form/demos/number/NumberForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { numberFormSchema, type NumberFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: NumberFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    numberFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('count').id}>Count</label>
+        <input
+          {...form.field('count').attributes({ as: 'number' })}
+          class="control"
+          class:invalid={form.shownErrors['count']}
+          aria-describedby={form.field('count').id + 'desc'}
+        />
+        <div id={form.field('count').id + 'desc'}>
+          {#if form.shownErrors['count']}
+            <div class="text-red-600">{form.shownErrors['count']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/number/schema.ts
+++ b/src/routes/form/demos/number/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const numberFormSchema = z.object({
+  count: z.number({ error: 'Required.' }).int('Must be a whole number.')
+});
+export type NumberFormData = z.infer<typeof numberFormSchema>;

--- a/src/routes/form/demos/password/+page.server.ts
+++ b/src/routes/form/demos/password/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { passwordFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './PasswordForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, passwordFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'PasswordForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(passwordFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, passwordFormSchema, handler.data);
+    return handler.succeed({ message: `Password accepted (${handler.data.password.length} chars).`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/password/+page.svelte
+++ b/src/routes/form/demos/password/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import PasswordForm from './PasswordForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Password Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/password'), label: 'Password' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><PasswordForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/password/PasswordForm.svelte
+++ b/src/routes/form/demos/password/PasswordForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { passwordFormSchema, type PasswordFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: PasswordFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    passwordFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('password').id}>Password</label>
+        <input
+          {...form.field('password').attributes({ as: 'password' })}
+          class="control"
+          class:invalid={form.shownErrors['password']}
+          aria-describedby={form.field('password').id + 'desc'}
+        />
+        <div id={form.field('password').id + 'desc'}>
+          {#if form.shownErrors['password']}
+            <div class="text-red-600">{form.shownErrors['password']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/password/schema.ts
+++ b/src/routes/form/demos/password/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const passwordFormSchema = z.object({
+  password: z.string().min(8, 'At least 8 characters required.')
+});
+export type PasswordFormData = z.infer<typeof passwordFormSchema>;

--- a/src/routes/form/demos/range/+page.server.ts
+++ b/src/routes/form/demos/range/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { rangeFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './RangeForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, rangeFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'RangeForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(rangeFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, rangeFormSchema, handler.data);
+    return handler.succeed({ message: `You selected ${handler.data.value}.`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/range/+page.svelte
+++ b/src/routes/form/demos/range/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import RangeForm from './RangeForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Range Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/range'), label: 'Range' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><RangeForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/range/RangeForm.svelte
+++ b/src/routes/form/demos/range/RangeForm.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { rangeFormSchema, type RangeFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: RangeFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    rangeFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('value').id}>Value (0–100)</label>
+        <input
+          {...form.field('value').attributes({ as: 'range' })}
+          min="0"
+          max="100"
+          class="w-full"
+          aria-describedby={form.field('value').id + 'desc'}
+        />
+        <div id={form.field('value').id + 'desc'}>
+          {#if form.shownErrors['value']}
+            <div class="text-red-600">{form.shownErrors['value']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/range/schema.ts
+++ b/src/routes/form/demos/range/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const rangeFormSchema = z.object({
+  value: z.number({ error: 'Required.' }).min(0).max(100)
+});
+export type RangeFormData = z.infer<typeof rangeFormSchema>;

--- a/src/routes/form/demos/search/+page.server.ts
+++ b/src/routes/form/demos/search/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { searchFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './SearchForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, searchFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'SearchForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(searchFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, searchFormSchema, handler.data);
+    return handler.succeed({ message: `You searched for "${handler.data.query}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/search/+page.svelte
+++ b/src/routes/form/demos/search/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import SearchForm from './SearchForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Search Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/search'), label: 'Search' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><SearchForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/search/SearchForm.svelte
+++ b/src/routes/form/demos/search/SearchForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { searchFormSchema, type SearchFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: SearchFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    searchFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('query').id}>Search Query</label>
+        <input
+          {...form.field('query').attributes({ as: 'search' })}
+          class="control"
+          class:invalid={form.shownErrors['query']}
+          aria-describedby={form.field('query').id + 'desc'}
+        />
+        <div id={form.field('query').id + 'desc'}>
+          {#if form.shownErrors['query']}
+            <div class="text-red-600">{form.shownErrors['query']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/search/schema.ts
+++ b/src/routes/form/demos/search/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const searchFormSchema = z.object({
+  query: z.string().min(1, 'Required.')
+});
+export type SearchFormData = z.infer<typeof searchFormSchema>;

--- a/src/routes/form/demos/tel/+page.server.ts
+++ b/src/routes/form/demos/tel/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { telFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './TelForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, telFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'TelForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(telFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, telFormSchema, handler.data);
+    return handler.succeed({ message: `You entered "${handler.data.phone}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/tel/+page.svelte
+++ b/src/routes/form/demos/tel/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import TelForm from './TelForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Tel Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/tel'), label: 'Tel' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><TelForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/tel/TelForm.svelte
+++ b/src/routes/form/demos/tel/TelForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { telFormSchema, type TelFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: TelFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    telFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('phone').id}>Phone</label>
+        <input
+          {...form.field('phone').attributes({ as: 'tel' })}
+          class="control"
+          class:invalid={form.shownErrors['phone']}
+          aria-describedby={form.field('phone').id + 'desc'}
+        />
+        <div id={form.field('phone').id + 'desc'}>
+          {#if form.shownErrors['phone']}
+            <div class="text-red-600">{form.shownErrors['phone']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/tel/schema.ts
+++ b/src/routes/form/demos/tel/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const telFormSchema = z.object({
+  phone: z.string().min(1, 'Required.')
+});
+export type TelFormData = z.infer<typeof telFormSchema>;

--- a/src/routes/form/demos/text/+page.server.ts
+++ b/src/routes/form/demos/text/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { textFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './TextForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, textFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'TextForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(textFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, textFormSchema, handler.data);
+    return handler.succeed({ message: `You entered "${handler.data.text}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/text/+page.svelte
+++ b/src/routes/form/demos/text/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import TextForm from './TextForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Text Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/text'), label: 'Text' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><TextForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/text/TextForm.svelte
+++ b/src/routes/form/demos/text/TextForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { textFormSchema, type TextFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: TextFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    textFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('text').id}>Text</label>
+        <input
+          {...form.field('text').attributes({ as: 'text' })}
+          class="control"
+          class:invalid={form.shownErrors['text']}
+          aria-describedby={form.field('text').id + 'desc'}
+        />
+        <div id={form.field('text').id + 'desc'}>
+          {#if form.shownErrors['text']}
+            <div class="text-red-600">{form.shownErrors['text']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/text/schema.ts
+++ b/src/routes/form/demos/text/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const textFormSchema = z.object({
+  text: z.string().min(1, 'Required.')
+});
+export type TextFormData = z.infer<typeof textFormSchema>;

--- a/src/routes/form/demos/textarea/+page.server.ts
+++ b/src/routes/form/demos/textarea/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { textareaFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './TextareaForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, textareaFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'TextareaForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(textareaFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, textareaFormSchema, handler.data);
+    return handler.succeed({ message: `Message received (${handler.data.message.length} chars).`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/textarea/+page.svelte
+++ b/src/routes/form/demos/textarea/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import TextareaForm from './TextareaForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Textarea"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/textarea'), label: 'Textarea' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><TextareaForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/textarea/TextareaForm.svelte
+++ b/src/routes/form/demos/textarea/TextareaForm.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { textareaFormSchema, type TextareaFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: TextareaFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    textareaFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('message').id}>Message</label>
+        <textarea
+          {...form.field('message').attributes({ as: 'textarea' })}
+          class="control"
+          class:invalid={form.shownErrors['message']}
+          aria-describedby={form.field('message').id + 'desc'}
+          rows={4}
+        ></textarea>
+        <div id={form.field('message').id + 'desc'}>
+          {#if form.shownErrors['message']}
+            <div class="text-red-600">{form.shownErrors['message']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/textarea/schema.ts
+++ b/src/routes/form/demos/textarea/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const textareaFormSchema = z.object({
+  message: z.string().min(1, 'Required.')
+});
+export type TextareaFormData = z.infer<typeof textareaFormSchema>;

--- a/src/routes/form/demos/time/+page.server.ts
+++ b/src/routes/form/demos/time/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { timeFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './TimeForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, timeFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'TimeForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(timeFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, timeFormSchema, handler.data);
+    return handler.succeed({ message: `You selected "${handler.data.time}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/time/+page.svelte
+++ b/src/routes/form/demos/time/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import TimeForm from './TimeForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Time Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/time'), label: 'Time' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><TimeForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/time/TimeForm.svelte
+++ b/src/routes/form/demos/time/TimeForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { timeFormSchema, type TimeFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: TimeFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    timeFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('time').id}>Time</label>
+        <input
+          {...form.field('time').attributes({ as: 'time' })}
+          class="control"
+          class:invalid={form.shownErrors['time']}
+          aria-describedby={form.field('time').id + 'desc'}
+        />
+        <div id={form.field('time').id + 'desc'}>
+          {#if form.shownErrors['time']}
+            <div class="text-red-600">{form.shownErrors['time']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/time/schema.ts
+++ b/src/routes/form/demos/time/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const timeFormSchema = z.object({
+  time: z.string().min(1, 'Required.')
+});
+export type TimeFormData = z.infer<typeof timeFormSchema>;

--- a/src/routes/form/demos/url/+page.server.ts
+++ b/src/routes/form/demos/url/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { urlFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './UrlForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, urlFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'UrlForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(urlFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, urlFormSchema, handler.data);
+    return handler.succeed({ message: `You entered "${handler.data.website}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/url/+page.svelte
+++ b/src/routes/form/demos/url/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import UrlForm from './UrlForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="URL Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/url'), label: 'URL' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><UrlForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/url/UrlForm.svelte
+++ b/src/routes/form/demos/url/UrlForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { urlFormSchema, type UrlFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: UrlFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    urlFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('website').id}>Website URL</label>
+        <input
+          {...form.field('website').attributes({ as: 'url' })}
+          class="control"
+          class:invalid={form.shownErrors['website']}
+          aria-describedby={form.field('website').id + 'desc'}
+        />
+        <div id={form.field('website').id + 'desc'}>
+          {#if form.shownErrors['website']}
+            <div class="text-red-600">{form.shownErrors['website']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/url/schema.ts
+++ b/src/routes/form/demos/url/schema.ts
@@ -1,0 +1,10 @@
+import z from 'zod';
+
+export const urlFormSchema = z.object({
+  website: z
+    .string({ error: 'Required.' })
+    .trim()
+    .min(1, { error: 'Required.' })
+    .pipe(z.url({ error: 'Invalid URL.' }))
+});
+export type UrlFormData = z.infer<typeof urlFormSchema>;

--- a/src/routes/form/demos/week/+page.server.ts
+++ b/src/routes/form/demos/week/+page.server.ts
@@ -1,0 +1,36 @@
+import { deleteDemoCookie, getDemoCookie, setDemoCookie } from '$demo/demo-cookies.js';
+import { ServerFormHandler } from 'skimpleton';
+import type { RequestEvent, Actions } from './$types.js';
+import { weekFormSchema } from './schema.js';
+import z from 'zod';
+
+import schemaTs from './schema.ts?raw';
+import pageServerTs from './+page.server.ts?raw';
+import pageSvelte from './+page.svelte?raw';
+import formSvelte from './WeekForm.svelte?raw';
+
+export const load = (event: RequestEvent) => {
+  return {
+    saved: getDemoCookie(event, weekFormSchema),
+    code: [
+      { label: 'schema.ts', language: 'typescript', code: schemaTs },
+      { label: 'WeekForm.svelte', language: 'html', code: formSvelte },
+      { label: '+page.svelte', language: 'html', code: pageSvelte },
+      { label: '+page.server.ts', language: 'typescript', code: pageServerTs }
+    ]
+  };
+};
+
+export const actions: Actions = {
+  selectDemo: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(weekFormSchema, await event.request.formData(), event);
+    if (!handler.valid) return handler.fail();
+    setDemoCookie(event, weekFormSchema, handler.data);
+    return handler.succeed({ message: `You selected "${handler.data.week}".`, randomNum: Math.random() });
+  },
+  deleteSaved: async (event: RequestEvent) => {
+    const handler = new ServerFormHandler(z.object({}), new FormData(), event);
+    deleteDemoCookie(event);
+    return handler.succeed({ message: 'Deleted saved data.' });
+  }
+};

--- a/src/routes/form/demos/week/+page.svelte
+++ b/src/routes/form/demos/week/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Route from '$demo/components/Route.svelte';
+  import { resolve } from '$app/paths';
+  import WeekForm from './WeekForm.svelte';
+  import CodeTabs from '$demo/components/CodeTabs.svelte';
+  let { data, form } = $props();
+</script>
+
+<Route
+  fullWidth
+  pageTitle="Week Input"
+  breadcrumbs={[
+    { href: resolve('/'), label: 'Home' },
+    { href: resolve('/form'), label: 'Forms' },
+    { href: resolve('/form/demos'), label: 'Demos' },
+    { href: resolve('/form/demos/week'), label: 'Week' }
+  ]}
+>
+  <div class="grid items-start gap-16 lg:grid-cols-2">
+    <div><WeekForm actionData={form} savedData={data.saved} /></div>
+    <div><CodeTabs tabs={data.code} /></div>
+  </div>
+</Route>

--- a/src/routes/form/demos/week/WeekForm.svelte
+++ b/src/routes/form/demos/week/WeekForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ClientFormHandler } from 'skimpleton';
+  import { weekFormSchema, type WeekFormData } from './schema.ts';
+  import type { ActionData } from './$types.js';
+  import DemoFormData from '$demo/components/DemoFormData.svelte';
+
+  type Props = { actionData: ActionData; savedData?: WeekFormData };
+  let { actionData, savedData }: Props = $props();
+  // svelte-ignore state_referenced_locally
+  const form = new ClientFormHandler(
+    weekFormSchema,
+    actionData ? actionData : savedData ? { data: savedData } : { data: {} }
+  );
+</script>
+
+<div class="space-y-8">
+  <div class="border border-gray-200">
+    <h3 class="bg-gray-200 px-4 py-2 font-semibold">Demo Form</h3>
+    <form {...form.attributes()} action="?/selectDemo" class="space-y-4 p-4">
+      <div class="space-y-1">
+        <label for={form.field('week').id}>Week</label>
+        <input
+          {...form.field('week').attributes({ as: 'week' })}
+          class="control"
+          class:invalid={form.shownErrors['week']}
+          aria-describedby={form.field('week').id + 'desc'}
+        />
+        <div id={form.field('week').id + 'desc'}>
+          {#if form.shownErrors['week']}
+            <div class="text-red-600">{form.shownErrors['week']}</div>
+          {/if}
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button class="button primary" type="submit">
+          <span class="icon-[bi--save]"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+  <DemoFormData handler={form} {savedData} />
+</div>

--- a/src/routes/form/demos/week/schema.ts
+++ b/src/routes/form/demos/week/schema.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+
+export const weekFormSchema = z.object({
+  week: z.string().min(1, 'Required.')
+});
+export type WeekFormData = z.infer<typeof weekFormSchema>;


### PR DESCRIPTION
## Summary

- Add demo routes for all `StringField` input types: `text`, `email`, `password`, `search`, `tel`, `url`, `date`, `time`, `datetime-local`, `month`, `week`, `color`, `textarea`
- Add demo routes for `NumericField` input types: `number`, `range`
- Add demo routes for file inputs: single (`z.file()`) and multiple (`z.array(z.file())`)

## Library fixes & improvements

- **`enctype` auto-set**: `form.attributes()` now includes `enctype="multipart/form-data"` automatically when the form contains file fields
- **File touched state**: file inputs are no longer marked touched on `focusout` (which fired when the OS picker opened); instead marked touched on `change`
- **Empty file placeholder**: browsers submit a sentinel empty `File` when no file is selected — `formDataToPojo` now filters these out so file array fields correctly return `[]`
- **`novalidate` progressive enhancement**: a dedicated client-side attachment sets `novalidate` on the form when JS is active, suppressing duplicate browser validation UI; SSR output is unaffected so native validation works in the no-JS case

## Test plan

- [ ] Visit `/form/demos` and confirm all new routes are listed and navigable
- [ ] Test each textual input type: blur without input → "Required." error; valid input → saves successfully
- [ ] Test `email` and `url`: invalid format shows "Invalid email." / "Invalid URL."; valid saves
- [ ] Test `file` (single): select a file → saves; no selection + submit → validation error shown only after touched
- [ ] Test `file-multiple`: select multiple files → saves; cancel picker does not leave phantom entries in Data panel
- [ ] Test `number`: non-integer or empty → error; valid integer → saves
- [ ] Test `range`: slider submits value within 0–100
- [ ] Confirm no browser native validation tooltip appears on any demo (novalidate active with JS)
- [ ] Disable JS, reload a demo with a required field, submit empty → browser native validation tooltip appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)