### PR TITLE
fix: clear all external errors on any input change

### DIFF
--- a/src/lib/form/client-form-handler.svelte.ts
+++ b/src/lib/form/client-form-handler.svelte.ts
@@ -277,11 +277,8 @@ export class ClientFormHandler<
       [this.#enhanceAttachmentKey]: this.#enhanceAttachment,
       oninput: (event) => {
         this.#formData = new FormData(event.currentTarget);
-        const name = (event.target as HTMLInputElement).name as FormName<T>;
-        if (name && name in this.#externalErrors) {
-          const updated = { ...this.#externalErrors };
-          delete updated[name];
-          this.#externalErrors = updated;
+        if (Object.keys(this.#externalErrors).length > 0) {
+          this.#externalErrors = {};
         }
       },
       onfocusout: (event) => {


### PR DESCRIPTION
## Summary

- Fixes an edge case where server errors dependent on multiple fields were not cleared when a non-errored dependent field was changed
- Any `oninput` event now clears all `externalErrors`, treating the prior server response as stale once the user edits anything

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)