### PR TITLE
fix: remove gratuitous fromAction wrapper from novalidate attachment

### DIFF
--- a/src/lib/form/client-form-handler.svelte.ts
+++ b/src/lib/form/client-form-handler.svelte.ts
@@ -106,14 +106,12 @@ export class ClientFormHandler<
     this.#success = $state(initialState?.success ?? undefined);
 
     this.#novalidateKey = createAttachmentKey();
-    this.#novalidateAttachment = fromAction((node: HTMLFormElement) => {
+    this.#novalidateAttachment = (node: HTMLFormElement) => {
       node.setAttribute('novalidate', '');
-      return {
-        destroy() {
-          node.removeAttribute('novalidate');
-        }
+      return () => {
+        node.removeAttribute('novalidate');
       };
-    });
+    };
     this.#enhanceAttachmentKey = createAttachmentKey();
     this.#enhanceAttachment = fromAction(
       enhance as Action<


### PR DESCRIPTION
## Summary

- Removes the unnecessary `fromAction` wrapper around the `#novalidateAttachment` assignment
- Uses the native attachment function signature directly, with a plain cleanup function returned instead of a `{ destroy() {} }` object
- Fixes #11

## Test plan

- [ ] Verify forms still receive `novalidate` attribute on mount
- [ ] Verify `novalidate` attribute is removed on cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)