### PR TITLE
feat: add unit tests for form library

### DIFF
--- a/src/lib/form/client-form-handler.svelte.test.ts
+++ b/src/lib/form/client-form-handler.svelte.test.ts
@@ -1,0 +1,403 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ClientFormHandler } from './client-form-handler.svelte.js';
+import z from 'zod';
+
+// SvelteKit browser modules are not available in the test environment;
+// mock them so the constructor can run without errors.
+vi.mock('$app/forms', () => ({ enhance: vi.fn() }));
+vi.mock('$app/navigation', () => ({ goto: vi.fn(), invalidateAll: vi.fn() }));
+vi.mock('$lib/message/message.svelte.js', () => ({
+  MessageService: {
+    get: vi.fn(() => ({
+      error: vi.fn(),
+      wait: vi.fn(),
+      success: vi.fn(),
+      clear: vi.fn()
+    }))
+  }
+}));
+
+// ---------------------------------------------------------------------------
+// Shared schemas
+// ---------------------------------------------------------------------------
+
+const simpleSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  bio: z.string()
+});
+
+const richSchema = z.object({
+  name: z.string(),
+  active: z.boolean(),
+  age: z.number(),
+  tags: z.array(z.string()),
+  avatar: z.file().optional()
+});
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+describe('ClientFormHandler — constructor', () => {
+  it('generates a formId matching skf-* pattern', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    expect(handler.formId).toMatch(/^skf-[a-z0-9]+$/);
+  });
+
+  it('initialises formData from initialState.data', () => {
+    const handler = new ClientFormHandler(simpleSchema, {
+      data: { name: 'Alice', bio: 'Hello' }
+    });
+    expect(handler.formData.get('name')).toBe('Alice');
+    expect(handler.formData.get('bio')).toBe('Hello');
+  });
+
+  it('uses schema defaults when no initialState is provided', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    expect(handler.formData.get('name')).toBe('');
+    expect(handler.formData.get('bio')).toBe('');
+  });
+
+  it('pre-touches fields that have errors in initialState', () => {
+    const handler = new ClientFormHandler(simpleSchema, {
+      errors: { name: 'Too short' }
+    });
+    expect(handler.touched.name).toBe(true);
+    expect(handler.touched.bio).toBeUndefined();
+  });
+
+  it('sets externalErrors from initialState.errors', () => {
+    const handler = new ClientFormHandler(simpleSchema, {
+      errors: { name: 'Server error' }
+    });
+    expect(handler.externalErrors.name).toBe('Server error');
+  });
+
+  it('sets success from initialState.success', () => {
+    const handler = new ClientFormHandler(simpleSchema, {
+      success: { isRedirect: false, message: 'Saved!' }
+    });
+    expect(handler.success).toMatchObject({ message: 'Saved!' });
+  });
+
+  it('builds fieldDefinitions for every schema field', () => {
+    const handler = new ClientFormHandler(richSchema);
+    expect(handler.fieldDefinitions.has('name')).toBe(true);
+    expect(handler.fieldDefinitions.has('active')).toBe(true);
+    expect(handler.fieldDefinitions.has('age')).toBe(true);
+    expect(handler.fieldDefinitions.has('tags')).toBe(true);
+    expect(handler.fieldDefinitions.has('avatar')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Touch tracking
+// ---------------------------------------------------------------------------
+
+describe('ClientFormHandler — touch tracking', () => {
+  let handler: ClientFormHandler<typeof simpleSchema._output>;
+
+  beforeEach(() => {
+    handler = new ClientFormHandler(simpleSchema);
+  });
+
+  it('touch() marks a single field as touched', () => {
+    handler.touch('name');
+    expect(handler.touched.name).toBe(true);
+    expect(handler.touched.bio).toBeUndefined();
+  });
+
+  it('touchAll() marks every field as touched', () => {
+    handler.touchAll();
+    expect(handler.touched.name).toBe(true);
+    expect(handler.touched.bio).toBe(true);
+  });
+
+  it('untouch() removes touch for a single field', () => {
+    handler.touchAll();
+    handler.untouch('name');
+    expect(handler.touched.name).toBeUndefined();
+    expect(handler.touched.bio).toBe(true);
+  });
+
+  it('untouchAll() clears all touches', () => {
+    handler.touchAll();
+    handler.untouchAll();
+    expect(Object.keys(handler.touched).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// errors / shownErrors / valid
+// ---------------------------------------------------------------------------
+
+describe('ClientFormHandler — errors, shownErrors, valid', () => {
+  it('valid is false when required fields are empty', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    expect(handler.valid).toBe(false);
+  });
+
+  it('valid is true when all fields satisfy the schema', () => {
+    const handler = new ClientFormHandler(simpleSchema, {
+      data: { name: 'Alice', bio: '' }
+    });
+    expect(handler.valid).toBe(true);
+  });
+
+  it('shownErrors is empty when nothing is touched', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    expect(handler.shownErrors).toEqual({});
+  });
+
+  it('shownErrors surfaces errors for touched fields', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    handler.touch('name');
+    expect(handler.shownErrors.name).toBe('Name is required');
+    expect(handler.shownErrors.bio).toBeUndefined(); // not touched
+  });
+
+  it('shownErrors surfaces all errors after touchAll()', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    handler.touchAll();
+    expect(handler.shownErrors.name).toBe('Name is required');
+  });
+
+  it('externalErrors merge on top of computed errors', () => {
+    const handler = new ClientFormHandler(simpleSchema, {
+      errors: { bio: 'Server says bio is invalid' }
+    });
+    handler.touch('bio');
+    // bio passes schema validation (empty string is ok) but has an external error
+    expect(handler.shownErrors.bio).toBe('Server says bio is invalid');
+  });
+
+  it('computedErrors reflects the current formData', () => {
+    const handler = new ClientFormHandler(simpleSchema, {
+      data: { name: 'Alice', bio: '' }
+    });
+    // 'Alice' satisfies min(1) → no name error
+    expect(handler.computedErrors.name).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attributes()
+// ---------------------------------------------------------------------------
+
+describe('ClientFormHandler — attributes()', () => {
+  it('always includes method="post"', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    expect(handler.attributes().method).toBe('post');
+  });
+
+  it('does not include enctype when there are no file fields', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    expect(handler.attributes().enctype).toBeUndefined();
+  });
+
+  it('includes enctype="multipart/form-data" when schema has a file field', () => {
+    const handler = new ClientFormHandler(richSchema);
+    expect(handler.attributes().enctype).toBe('multipart/form-data');
+  });
+
+  it('oninput clears externalErrors', () => {
+    const handler = new ClientFormHandler(simpleSchema, {
+      errors: { name: 'Server error' }
+    });
+    expect(handler.externalErrors.name).toBe('Server error');
+
+    const form = document.createElement('form');
+    handler.attributes().oninput!({ currentTarget: form } as InputEvent & {
+      currentTarget: HTMLFormElement;
+    });
+    expect(handler.externalErrors).toEqual({});
+  });
+
+  it('oninput does not clear externalErrors when there are none', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    const form = document.createElement('form');
+    // Should not throw and externalErrors should remain empty
+    handler.attributes().oninput!({ currentTarget: form } as InputEvent & {
+      currentTarget: HTMLFormElement;
+    });
+    expect(handler.externalErrors).toEqual({});
+  });
+
+  it('onfocusout touches a non-file field', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    const input = document.createElement('input');
+    input.name = 'name';
+    expect(handler.touched.name).toBeUndefined();
+    handler.attributes().onfocusout!({
+      target: input
+    } as unknown as FocusEvent & {
+      currentTarget: EventTarget & HTMLFormElement;
+    });
+    expect(handler.touched.name).toBe(true);
+  });
+
+  it('onfocusout does not touch a file field', () => {
+    const handler = new ClientFormHandler(richSchema);
+    const input = document.createElement('input');
+    input.name = 'avatar';
+    handler.attributes().onfocusout!({
+      target: input
+    } as unknown as FocusEvent & {
+      currentTarget: EventTarget & HTMLFormElement;
+    });
+    expect(handler.touched.avatar).toBeUndefined();
+  });
+
+  it('onchange touches a file field', () => {
+    const handler = new ClientFormHandler(richSchema);
+    const input = document.createElement('input');
+    input.name = 'avatar';
+    expect(handler.touched.avatar).toBeUndefined();
+    handler.attributes().onchange!({ target: input } as unknown as Event & {
+      currentTarget: EventTarget & HTMLFormElement;
+    });
+    expect(handler.touched.avatar).toBe(true);
+  });
+
+  it('onchange does not touch a non-file field', () => {
+    const handler = new ClientFormHandler(richSchema);
+    const input = document.createElement('input');
+    input.name = 'name';
+    handler.attributes().onchange!({ target: input } as unknown as Event & {
+      currentTarget: EventTarget & HTMLFormElement;
+    });
+    expect(handler.touched.name).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// field() — type dispatch
+// ---------------------------------------------------------------------------
+
+describe('ClientFormHandler — field()', () => {
+  const handler = new ClientFormHandler(richSchema);
+
+  it('returns a StringField for a string field', () => {
+    const field = handler.field('name');
+    expect(typeof field.inputAttributes).toBe('function');
+  });
+
+  it('returns a BooleanField for a boolean field', () => {
+    const field = handler.field('active');
+    expect(typeof field.checkboxAttributes).toBe('function');
+  });
+
+  it('returns a NumericField for a number field', () => {
+    const field = handler.field('age');
+    expect(typeof field.inputAttributes).toBe('function');
+  });
+
+  it('returns a StringMultipleChoiceField for a string array field', () => {
+    const field = handler.field('tags');
+    expect(typeof field.checkboxAttributes).toBe('function');
+    expect(typeof field.selectAttributes).toBe('function');
+  });
+
+  it('returns a FileField for a file field', () => {
+    const field = handler.field('avatar');
+    expect(typeof field.inputAttributes).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Field attribute methods — spot checks
+// ---------------------------------------------------------------------------
+
+describe('ClientFormHandler — field attribute methods', () => {
+  it('StringField.inputAttributes() returns correct name, id, type, and value', () => {
+    const handler = new ClientFormHandler(simpleSchema, {
+      data: { name: 'Alice', bio: '' }
+    });
+    const attrs = handler.field('name').inputAttributes('text');
+    expect(attrs.name).toBe('name');
+    expect(attrs.id).toMatch(/^skf-.+-name$/);
+    expect(attrs.type).toBe('text');
+    expect(attrs.value).toBe('Alice');
+  });
+
+  it('StringField.inputAttributes() reflects updated formData value', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    expect(handler.field('name').inputAttributes('text').value).toBe('');
+  });
+
+  it('BooleanField.checkboxAttributes() reflects checked state', () => {
+    const boolSchema = z.object({ active: z.boolean().default(true) });
+    const handler = new ClientFormHandler(boolSchema);
+    expect(handler.field('active').checkboxAttributes().checked).toBe(true);
+  });
+
+  it('BooleanField.checkboxAttributes() is unchecked when false', () => {
+    const boolSchema = z.object({ active: z.boolean() });
+    const handler = new ClientFormHandler(boolSchema);
+    expect(handler.field('active').checkboxAttributes().checked).toBe(false);
+  });
+
+  it('NumericField.inputAttributes() returns value as string', () => {
+    const numSchema = z.object({ age: z.number().default(25) });
+    const handler = new ClientFormHandler(numSchema);
+    const attrs = handler.field('age').inputAttributes('number');
+    expect(attrs.value).toBe('25');
+    expect(attrs.type).toBe('number');
+  });
+
+  it('StringMultipleChoiceField.checkboxAttributes() reflects checked state', () => {
+    const arrSchema = z.object({
+      tags: z.array(z.string()).default(['a', 'b'])
+    });
+    const handler = new ClientFormHandler(arrSchema);
+    expect(handler.field('tags').checkboxAttributes('a').checked).toBe(true);
+    expect(handler.field('tags').checkboxAttributes('c').checked).toBe(false);
+  });
+
+  it('FileField.inputAttributes() returns type=file and correct multiple flag', () => {
+    const singleFileSchema = z.object({ doc: z.file().optional() });
+    const multiFileSchema = z.object({ docs: z.array(z.file()).default([]) });
+
+    const single = new ClientFormHandler(singleFileSchema);
+    expect(single.field('doc').inputAttributes().type).toBe('file');
+    expect(single.field('doc').inputAttributes().multiple).toBe(false);
+
+    const multi = new ClientFormHandler(multiFileSchema);
+    expect(multi.field('docs').inputAttributes().multiple).toBe(true);
+  });
+
+  it('BooleanField.radioAttributes() returns correct value and checked', () => {
+    const boolSchema = z.object({ agreed: z.boolean().default(true) });
+    const handler = new ClientFormHandler(boolSchema);
+    const onAttrs = handler.field('agreed').radioAttributes(true);
+    const offAttrs = handler.field('agreed').radioAttributes(false);
+    expect(onAttrs.value).toBe('on');
+    expect(onAttrs.checked).toBe(true);
+    expect(offAttrs.value).toBe('');
+    expect(offAttrs.checked).toBe(false);
+  });
+
+  it('StringField.textareaAttributes() returns value', () => {
+    const handler = new ClientFormHandler(simpleSchema, {
+      data: { name: 'Alice', bio: 'Hello world' }
+    });
+    expect(handler.field('bio').textareaAttributes().value).toBe('Hello world');
+  });
+
+  it('StringField.optionAttributes() returns selected=true for matching value', () => {
+    const enumSchema = z.object({ color: z.enum(['red', 'green', 'blue']) });
+    const handler = new ClientFormHandler(enumSchema, {
+      data: { color: 'green' }
+    });
+    expect(handler.field('color').optionAttributes('green').selected).toBe(
+      true
+    );
+    expect(handler.field('color').optionAttributes('red').selected).toBe(false);
+  });
+
+  it('field id uses formId as prefix', () => {
+    const handler = new ClientFormHandler(simpleSchema);
+    const field = handler.field('name');
+    expect(field.id.startsWith(handler.formId)).toBe(true);
+  });
+});

--- a/src/lib/form/server-form-handler.test.ts
+++ b/src/lib/form/server-form-handler.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ServerFormHandler } from './server-form-handler.js';
+import z from 'zod';
+import { FlashMessage } from '$lib/message/flash-message.js';
+import { fail, redirect } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+
+vi.mock('@sveltejs/kit', () => ({
+  fail: vi.fn((status: number, data: unknown) => ({ status, data })),
+  redirect: vi.fn((status: number, location: string) => {
+    throw Object.assign(new Error(`Redirect to ${location}`), {
+      status,
+      location
+    });
+  })
+}));
+
+vi.mock('$lib/message/flash-message.js', () => ({
+  FlashMessage: { set: vi.fn() }
+}));
+
+function makeMockEvent(acceptHeader?: string): RequestEvent {
+  return {
+    request: new Request('http://localhost/', {
+      headers: acceptHeader ? { Accept: acceptHeader } : {}
+    }),
+    cookies: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      getAll: vi.fn().mockReturnValue([]),
+      serialize: vi.fn()
+    }
+  } as unknown as RequestEvent;
+}
+
+function makeFormData(values: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(values)) fd.set(k, v);
+  return fd;
+}
+
+const schema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  age: z.number()
+});
+
+describe('ServerFormHandler — constructor', () => {
+  it('sets valid=true and coerces data when FormData is valid', () => {
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: 'Alice', age: '30' }),
+      makeMockEvent()
+    );
+    expect(handler.valid).toBe(true);
+    expect(handler.data.name).toBe('Alice');
+    expect(handler.data.age).toBe(30); // string→number coercion via Zod
+    expect(handler.errors).toEqual({});
+  });
+
+  it('sets valid=false and populates errors when FormData is invalid', () => {
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: '', age: '25' }),
+      makeMockEvent()
+    );
+    expect(handler.valid).toBe(false);
+    expect(handler.errors.name).toBe('Name is required');
+  });
+
+  it('stores raw (un-transformed) data when validation fails', () => {
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: '', age: '99' }),
+      makeMockEvent()
+    );
+    // age came in as '99' → cast to 99 by formDataToPojo; Zod rejected due to name error
+    expect(handler.data.age).toBe(99);
+  });
+
+  it('exposes the RequestEvent on .event', () => {
+    const event = makeMockEvent();
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: 'Bob', age: '1' }),
+      event
+    );
+    expect(handler.event).toBe(event);
+  });
+});
+
+describe('ServerFormHandler#fail()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls fail(400, ...) with the current data and errors by default', () => {
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: '', age: '25' }),
+      makeMockEvent()
+    );
+    handler.fail();
+    expect(fail).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        errors: expect.objectContaining({ name: 'Name is required' })
+      })
+    );
+  });
+
+  it('uses custom errors when provided', () => {
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: '', age: '25' }),
+      makeMockEvent()
+    );
+    handler.fail({ name: 'Custom error' });
+    expect(fail).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({ errors: { name: 'Custom error' } })
+    );
+  });
+
+  it('uses a custom HTTP status when provided', () => {
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: '', age: '25' }),
+      makeMockEvent()
+    );
+    handler.fail(undefined, 422);
+    expect(fail).toHaveBeenCalledWith(422, expect.any(Object));
+  });
+
+  it('strips File objects from data via removeFiles', () => {
+    const fileSchema = z.object({
+      label: z.string(),
+      doc: z.file().optional()
+    });
+    const fd = new FormData();
+    fd.set('label', 'test');
+    fd.set('doc', new File(['x'], 'x.pdf'));
+    const handler = new ServerFormHandler(fileSchema, fd, makeMockEvent());
+    handler.fail();
+    const [, payload] = (fail as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(payload.data.doc).toBeUndefined();
+  });
+});
+
+describe('ServerFormHandler#succeed()', () => {
+  it('returns FormState with success and isRedirect=false', () => {
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: 'Alice', age: '30' }),
+      makeMockEvent()
+    );
+    const result = handler.succeed({ message: 'Saved!', id: 42 });
+    expect(result.success).toMatchObject({
+      isRedirect: false,
+      message: 'Saved!',
+      id: 42
+    });
+    expect(result.errors).toEqual({});
+  });
+
+  it('includes the current data in the result', () => {
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: 'Bob', age: '5' }),
+      makeMockEvent()
+    );
+    const result = handler.succeed({ message: 'OK' });
+    expect(result.data.name).toBe('Bob');
+  });
+
+  it('strips File objects from data', () => {
+    const fileSchema = z.object({
+      label: z.string(),
+      doc: z.file().optional()
+    });
+    const fd = new FormData();
+    fd.set('label', 'test');
+    fd.set('doc', new File(['x'], 'x.pdf'));
+    const handler = new ServerFormHandler(fileSchema, fd, makeMockEvent());
+    const result = handler.succeed({ message: 'OK' });
+    expect((result.data as { label: string; doc?: File }).doc).toBeUndefined();
+  });
+});
+
+describe('ServerFormHandler#redirect()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sets a flash message and throws redirect for non-fetch requests', () => {
+    const event = makeMockEvent('text/html,application/xhtml+xml');
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: 'Alice', age: '1' }),
+      event
+    );
+    expect(() => handler.redirect('/dashboard', 'Saved!')).toThrow();
+    expect(FlashMessage.set).toHaveBeenCalledWith(event, {
+      type: 'success',
+      message: 'Saved!'
+    });
+    expect(redirect).toHaveBeenCalledWith(303, '/dashboard');
+  });
+
+  it('uses a custom redirect status when provided', () => {
+    const event = makeMockEvent('text/html');
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: 'Alice', age: '1' }),
+      event
+    );
+    expect(() => handler.redirect('/home', 'Done', 301)).toThrow();
+    expect(redirect).toHaveBeenCalledWith(301, '/home');
+  });
+
+  it('returns a success state with isRedirect=true for fetch requests', () => {
+    const handler = new ServerFormHandler(
+      schema,
+      makeFormData({ name: 'Alice', age: '1' }),
+      makeMockEvent('application/json')
+    );
+    const result = handler.redirect('/dashboard', 'Saved!');
+    expect(result.success).toMatchObject({
+      isRedirect: true,
+      message: 'Saved!',
+      location: '/dashboard'
+    });
+    expect(result.errors).toEqual({});
+    expect(FlashMessage.set).not.toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/form/utils.test.ts
+++ b/src/lib/form/utils.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect } from 'vitest';
 import {
   unwrapZodType,
   getFormFieldDefinitions,
-  formDataToPojo
+  formDataToPojo,
+  pojoToFormData,
+  getDefaultData,
+  getFormErrors,
+  removeFiles,
+  isFetchRequest,
+  cloneFormData
 } from './utils.js';
 import z from 'zod';
 
@@ -303,5 +309,462 @@ describe('formDataToPojo — file fields', () => {
       const result = formDataToPojo(getFormFieldDefinitions(schema), fd);
       expect(result.attachments).toEqual([f1]);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Additional unwrapZodType cases
+// ---------------------------------------------------------------------------
+
+describe('unwrapZodType — additional wrappers', () => {
+  it('unwraps exactOptional', () => {
+    const inner = z.string();
+    expect(unwrapZodType(z.exactOptional(inner))).toBe(inner);
+  });
+
+  it('unwraps nonoptional', () => {
+    const inner = z.string();
+    expect(unwrapZodType(z.nonoptional(inner))).toBe(inner);
+  });
+
+  it('unwraps prefault', () => {
+    const inner = z.string();
+    expect(unwrapZodType(z.prefault(inner, () => 'x'))).toBe(inner);
+  });
+
+  it('unwraps lazy', () => {
+    const inner = z.string();
+    expect(unwrapZodType(z.lazy(() => inner))).toBe(inner);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Additional getFormFieldDefinitions cases
+// ---------------------------------------------------------------------------
+
+describe('getFormFieldDefinitions — scalar cast types and error paths', () => {
+  it('maps z.boolean() to castType "boolean"', () => {
+    const schema = z.object({ active: z.boolean() });
+    expect(getFormFieldDefinitions(schema).get('active')).toEqual({
+      name: 'active',
+      castType: 'boolean',
+      isArray: false
+    });
+  });
+
+  it('maps z.number() to castType "number"', () => {
+    const schema = z.object({ age: z.number() });
+    expect(getFormFieldDefinitions(schema).get('age')).toEqual({
+      name: 'age',
+      castType: 'number',
+      isArray: false
+    });
+  });
+
+  it('maps z.bigint() to castType "bigint"', () => {
+    const schema = z.object({ big: z.bigint() });
+    expect(getFormFieldDefinitions(schema).get('big')).toEqual({
+      name: 'big',
+      castType: 'bigint',
+      isArray: false
+    });
+  });
+
+  it('maps z.array(z.number()) to castType "number" isArray true', () => {
+    const schema = z.object({ scores: z.array(z.number()) });
+    expect(getFormFieldDefinitions(schema).get('scores')).toEqual({
+      name: 'scores',
+      castType: 'number',
+      isArray: true
+    });
+  });
+
+  it('throws for unsupported leaf type (z.date)', () => {
+    // z.date() is not a supported FormShape type; cast to bypass TS to test runtime behavior
+    const schema = z.object({ when: z.date() }) as never;
+    expect(() => getFormFieldDefinitions(schema)).toThrow();
+  });
+
+  it('throws when the top-level schema is not a ZodObject', () => {
+    expect(() => getFormFieldDefinitions(z.string() as never)).toThrow(
+      'The top level schema must be an instance of ZodObject.'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pojoToFormData
+// ---------------------------------------------------------------------------
+
+describe('pojoToFormData', () => {
+  it('sets a string field', () => {
+    const schema = z.object({ name: z.string() });
+    const defs = getFormFieldDefinitions(schema);
+    const fd = pojoToFormData(defs, { name: 'hello' });
+    expect(fd.get('name')).toBe('hello');
+  });
+
+  it('sets empty string for undefined string field', () => {
+    const schema = z.object({ name: z.string() });
+    const defs = getFormFieldDefinitions(schema);
+    const fd = pojoToFormData(defs, {});
+    expect(fd.get('name')).toBe('');
+  });
+
+  it('sets "on" for boolean true', () => {
+    const schema = z.object({ active: z.boolean() });
+    const defs = getFormFieldDefinitions(schema);
+    const fd = pojoToFormData(defs, { active: true });
+    expect(fd.get('active')).toBe('on');
+  });
+
+  it('omits boolean false', () => {
+    const schema = z.object({ active: z.boolean() });
+    const defs = getFormFieldDefinitions(schema);
+    const fd = pojoToFormData(defs, { active: false });
+    expect(fd.get('active')).toBeNull();
+  });
+
+  it('converts number to string', () => {
+    const schema = z.object({ age: z.number() });
+    const defs = getFormFieldDefinitions(schema);
+    const fd = pojoToFormData(defs, { age: 42 });
+    expect(fd.get('age')).toBe('42');
+  });
+
+  it('converts bigint to string', () => {
+    const schema = z.object({ big: z.bigint() });
+    const defs = getFormFieldDefinitions(schema);
+    const fd = pojoToFormData(defs, { big: 9007199254740993n });
+    expect(fd.get('big')).toBe('9007199254740993');
+  });
+
+  it('appends each item in a string array', () => {
+    const schema = z.object({ tags: z.array(z.string()) });
+    const defs = getFormFieldDefinitions(schema);
+    const fd = pojoToFormData(defs, { tags: ['a', 'b', 'c'] });
+    expect(fd.getAll('tags')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('appends each item in a number array as string', () => {
+    const schema = z.object({ scores: z.array(z.number()) });
+    const defs = getFormFieldDefinitions(schema);
+    const fd = pojoToFormData(defs, { scores: [1, 2, 3] });
+    expect(fd.getAll('scores')).toEqual(['1', '2', '3']);
+  });
+
+  it('sets a File field', () => {
+    const schema = z.object({ avatar: z.file() });
+    const defs = getFormFieldDefinitions(schema);
+    const f = new File(['content'], 'photo.jpg');
+    const fd = pojoToFormData(defs, { avatar: f });
+    expect(fd.get('avatar')).toBe(f);
+  });
+
+  it('omits a file field when undefined', () => {
+    const schema = z.object({ avatar: z.file().optional() });
+    const defs = getFormFieldDefinitions(schema);
+    const fd = pojoToFormData(defs, {});
+    expect(fd.get('avatar')).toBeNull();
+  });
+
+  it('appends each File in a file array', () => {
+    const schema = z.object({ files: z.array(z.file()) });
+    const defs = getFormFieldDefinitions(schema);
+    const f1 = new File(['a'], 'a.txt');
+    const f2 = new File(['b'], 'b.txt');
+    const fd = pojoToFormData(defs, { files: [f1, f2] });
+    expect(fd.getAll('files')).toEqual([f1, f2]);
+  });
+
+  it('handles nested dot-path fields', () => {
+    const schema = z.object({
+      name: z.object({ first: z.string(), last: z.string() })
+    });
+    const defs = getFormFieldDefinitions(schema);
+    const fd = pojoToFormData(defs, { name: { first: 'John', last: 'Doe' } });
+    expect(fd.get('name.first')).toBe('John');
+    expect(fd.get('name.last')).toBe('Doe');
+  });
+
+  it('throws when a non-array value is passed for an array field', () => {
+    const schema = z.object({ tags: z.array(z.string()) });
+    const defs = getFormFieldDefinitions(schema);
+    expect(() =>
+      pojoToFormData(defs, { tags: 'not-an-array' as never })
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDefaultData
+// ---------------------------------------------------------------------------
+
+describe('getDefaultData', () => {
+  it('returns empty string for z.string()', () => {
+    expect(getDefaultData(z.object({ name: z.string() }))).toEqual({
+      name: ''
+    });
+  });
+
+  it('returns 0 for z.number()', () => {
+    expect(getDefaultData(z.object({ age: z.number() }))).toEqual({ age: 0 });
+  });
+
+  it('returns false for z.boolean()', () => {
+    expect(getDefaultData(z.object({ active: z.boolean() }))).toEqual({
+      active: false
+    });
+  });
+
+  it('returns 0n for z.bigint()', () => {
+    expect(getDefaultData(z.object({ big: z.bigint() }))).toEqual({ big: 0n });
+  });
+
+  it('returns [] for z.array()', () => {
+    expect(getDefaultData(z.object({ tags: z.array(z.string()) }))).toEqual({
+      tags: []
+    });
+  });
+
+  it('returns the first enum option for z.enum()', () => {
+    expect(
+      getDefaultData(z.object({ color: z.enum(['red', 'green', 'blue']) }))
+    ).toEqual({ color: 'red' });
+  });
+
+  it('returns undefined for an optional field', () => {
+    const result = getDefaultData(z.object({ note: z.string().optional() }));
+    expect(result.note).toBeUndefined();
+  });
+
+  it('returns the default value for a field with .default()', () => {
+    expect(
+      getDefaultData(z.object({ name: z.string().default('Alice') }))
+    ).toEqual({ name: 'Alice' });
+  });
+
+  it('returns the catch value for a field with .catch()', () => {
+    expect(
+      getDefaultData(z.object({ name: z.string().catch('fallback') }))
+    ).toEqual({ name: 'fallback' });
+  });
+
+  it('returns undefined for z.file()', () => {
+    const result = getDefaultData(z.object({ avatar: z.file().optional() }));
+    expect(result.avatar).toBeUndefined();
+  });
+
+  it('recurses into nested objects', () => {
+    const schema = z.object({
+      name: z.object({ first: z.string(), last: z.string() })
+    });
+    expect(getDefaultData(schema)).toEqual({
+      name: { first: '', last: '' }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFormErrors
+// ---------------------------------------------------------------------------
+
+describe('getFormErrors', () => {
+  const schema = z.object({
+    name: z.string().min(1, 'Name is required'),
+    code: z.string().min(3, 'Too short')
+  });
+
+  it('returns {} when data is valid', () => {
+    expect(getFormErrors(schema, { name: 'Alice', code: 'ABC' })).toEqual({});
+  });
+
+  it('returns error message for an invalid field', () => {
+    const errors = getFormErrors(schema, { name: '', code: 'ABC' });
+    expect(errors.name).toBe('Name is required');
+    expect(errors.code).toBeUndefined();
+  });
+
+  it('returns errors for multiple invalid fields', () => {
+    const errors = getFormErrors(schema, { name: '', code: 'AB' });
+    expect(errors.name).toBe('Name is required');
+    expect(errors.code).toBe('Too short');
+  });
+
+  it('only records the first error per field path', () => {
+    // Two refinements that both fail produce two issues at the same path
+    const strictSchema = z.object({
+      pw: z
+        .string()
+        .refine(() => false, 'First error')
+        .refine(() => false, 'Second error')
+    });
+    const errors = getFormErrors(strictSchema, { pw: 'anything' });
+    expect(errors.pw).toBe('First error');
+    expect(Object.keys(errors).length).toBe(1);
+  });
+
+  it('ignores issues with no string path segments', () => {
+    // A top-level issue with an empty path yields formPath '' — skipped
+    const alwaysFailSchema = z.object({ x: z.string() }).refine(() => false, {
+      message: 'always fails',
+      path: []
+    });
+    const errors = getFormErrors(alwaysFailSchema, { x: 'ok' });
+    // The refine path is [] → formPath '' → skipped; field 'x' is valid
+    expect(errors).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeFiles
+// ---------------------------------------------------------------------------
+
+describe('removeFiles', () => {
+  it('returns null as-is', () => {
+    expect(removeFiles(null)).toBeNull();
+  });
+
+  it('returns undefined as-is', () => {
+    expect(removeFiles(undefined)).toBeUndefined();
+  });
+
+  it('replaces a File with undefined', () => {
+    expect(removeFiles(new File(['x'], 'x.txt'))).toBeUndefined();
+  });
+
+  it('passes through strings', () => {
+    expect(removeFiles('hello')).toBe('hello');
+  });
+
+  it('passes through numbers', () => {
+    expect(removeFiles(42)).toBe(42);
+  });
+
+  it('passes through booleans', () => {
+    expect(removeFiles(true)).toBe(true);
+  });
+
+  it('passes through bigint', () => {
+    expect(removeFiles(42n)).toBe(42n);
+  });
+
+  it('passes through Date by reference', () => {
+    const d = new Date();
+    expect(removeFiles(d)).toBe(d);
+  });
+
+  it('passes through RegExp by reference', () => {
+    const r = /foo/;
+    expect(removeFiles(r)).toBe(r);
+  });
+
+  it('passes through Map by reference', () => {
+    const m = new Map([['k', 'v']]);
+    expect(removeFiles(m)).toBe(m);
+  });
+
+  it('passes through Set by reference', () => {
+    const s = new Set([1, 2]);
+    expect(removeFiles(s)).toBe(s);
+  });
+
+  it('replaces File entries in an array', () => {
+    const f = new File(['x'], 'x.txt');
+    expect(removeFiles([f, 'text', 42])).toEqual([undefined, 'text', 42]);
+  });
+
+  it('replaces File values in an object', () => {
+    const f = new File(['x'], 'x.txt');
+    expect(removeFiles({ name: 'Alice', avatar: f })).toEqual({
+      name: 'Alice',
+      avatar: undefined
+    });
+  });
+
+  it('recurses into nested objects', () => {
+    const f = new File(['x'], 'x.txt');
+    expect(removeFiles({ user: { name: 'Alice', avatar: f } })).toEqual({
+      user: { name: 'Alice', avatar: undefined }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isFetchRequest
+// ---------------------------------------------------------------------------
+
+describe('isFetchRequest', () => {
+  it('returns true when Accept starts with application/json', () => {
+    const req = new Request('http://localhost/', {
+      headers: { Accept: 'application/json' }
+    });
+    expect(isFetchRequest(req)).toBe(true);
+  });
+
+  it('returns true when Accept starts with application/json followed by other types', () => {
+    const req = new Request('http://localhost/', {
+      headers: { Accept: 'application/json, text/html' }
+    });
+    expect(isFetchRequest(req)).toBe(true);
+  });
+
+  it('returns false when Accept is text/html', () => {
+    const req = new Request('http://localhost/', {
+      headers: { Accept: 'text/html,application/xhtml+xml' }
+    });
+    expect(isFetchRequest(req)).toBe(false);
+  });
+
+  it('returns false when Accept header is absent', () => {
+    const req = new Request('http://localhost/');
+    expect(isFetchRequest(req)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cloneFormData
+// ---------------------------------------------------------------------------
+
+describe('cloneFormData', () => {
+  it('copies a single string entry', () => {
+    const fd = new FormData();
+    fd.set('name', 'Alice');
+    const cloned = cloneFormData(fd);
+    expect(cloned.get('name')).toBe('Alice');
+  });
+
+  it('copies multiple values for the same key', () => {
+    const fd = new FormData();
+    fd.append('tags', 'a');
+    fd.append('tags', 'b');
+    fd.append('tags', 'c');
+    const cloned = cloneFormData(fd);
+    expect(cloned.getAll('tags')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('copies multiple distinct keys', () => {
+    const fd = new FormData();
+    fd.set('first', 'John');
+    fd.set('last', 'Doe');
+    const cloned = cloneFormData(fd);
+    expect(cloned.get('first')).toBe('John');
+    expect(cloned.get('last')).toBe('Doe');
+  });
+
+  it('mutating the clone does not affect the original', () => {
+    const fd = new FormData();
+    fd.set('name', 'Alice');
+    const cloned = cloneFormData(fd);
+    cloned.set('name', 'Bob');
+    expect(fd.get('name')).toBe('Alice');
+  });
+
+  it('mutating the original does not affect the clone', () => {
+    const fd = new FormData();
+    fd.set('name', 'Alice');
+    const cloned = cloneFormData(fd);
+    fd.set('name', 'Bob');
+    expect(cloned.get('name')).toBe('Alice');
   });
 });


### PR DESCRIPTION
Closes #7

## Summary

- **`utils.test.ts`** — expanded to cover all previously untested exports: `pojoToFormData`, `getDefaultData`, `getFormErrors`, `removeFiles`, `isFetchRequest`, `cloneFormData`, plus gap-fill cases for `unwrapZodType` (exactOptional, nonoptional, prefault, lazy) and `getFormFieldDefinitions` (boolean/number/bigint cast types, unsupported-type and non-ZodObject throws)
- **`server-form-handler.test.ts`** — new; tests `ServerFormHandler` constructor, `.fail()`, `.succeed()`, and `.redirect()` (both fetch and non-fetch paths) with mocked `@sveltejs/kit` and `FlashMessage`
- **`client-form-handler.svelte.test.ts`** — new browser test (`.svelte.test.ts`); covers constructor initialisation, touch/untouch tracking, reactive errors/shownErrors/valid state, `attributes()` event handlers, field type dispatch, and all field attribute methods

163 tests total, all passing across both the server (node) and client (Chromium) vitest projects.

## Test plan

- [x] `npx vitest run` — 163 tests pass
- [x] `npm run format` — no formatting changes
- [x] `npx svelte-check` — no type errors in test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)