### PR TITLE
feat: add markdown rendering with syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "clsx": "^2.1.1",
     "devalue": "^5.7.1",
     "highlight.js": "^11.11.1",
+    "marked": "^18.0.2",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      marked:
+        specifier: ^18.0.2
+        version: 18.0.2
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -1307,6 +1310,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@18.0.2:
+    resolution: {integrity: sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
@@ -2951,6 +2959,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@18.0.2: {}
 
   mdn-data@2.0.28: {}
 

--- a/src/demo/components/Markdown.svelte
+++ b/src/demo/components/Markdown.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { markdownToHtml } from '$demo/utils.js';
+
+  type Props = {
+    markdown: string;
+  };
+  let { markdown }: Props = $props();
+  let htmlOut = $derived(markdownToHtml(markdown));
+</script>
+
+<div class="prose">
+  <!-- eslint-disable svelte/no-at-html-tags -->
+  {@html htmlOut}
+  <!-- eslint-enable svelte/no-at-html-tags -->
+</div>

--- a/src/demo/utils.ts
+++ b/src/demo/utils.ts
@@ -1,6 +1,7 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import hljs, { type HighlightOptions } from 'highlight.js';
+import { Marked, Renderer } from 'marked';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -44,4 +45,15 @@ export const stripIgnored = (
     }
   }
   return curatedLines.join('\n');
+};
+
+export const markdownToHtml = (markdown: string): string => {
+  const renderer = new Renderer();
+  renderer.code = ({ text, lang }) => {
+    const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
+    const highlighted = hljs.highlight(text, { language }).value;
+    return `<div class="not-prose"><pre class="border border-gray-200 text-xs"><code class="hljs language-${language}">${highlighted}</code></pre></div>`;
+  };
+  const marked = new Marked({ renderer });
+  return marked.parse(markdown).toString();
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,4 @@
-<h1>Welcome to your library project</h1>
-<p>
-  Create your package using @sveltejs/package and preview/showcase your work
-  with SvelteKit
-</p>
-<p>
-  Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the
-  documentation
-</p>
+<script lang="ts">
+</script>
+
+<div class="px-auto container mx-auto my-8">Hello</div>


### PR DESCRIPTION
## Summary

- Adds `marked` as a dependency for Markdown parsing
- Adds `markdownToHtml` utility in `src/demo/utils.ts` using a custom `marked` renderer with highlight.js syntax highlighting; code blocks are wrapped in `<div class="not-prose">` to prevent Tailwind Typography prose styles from bleeding in
- Adds `Markdown.svelte` component that renders markdown inside a `prose` container

## Test plan

- [x] Verify code blocks render with syntax highlighting and are not affected by prose styles
- [x] Verify non-code markdown (paragraphs, lists, headings) renders correctly inside the `prose` container

🤖 Generated with [Claude Code](https://claude.com/claude-code)